### PR TITLE
feat: encode magic bytes WAL header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 wal-c
 # Local testing directory
 wal-test
+*.wal

--- a/main.c
+++ b/main.c
@@ -125,7 +125,13 @@ int main(int argc, char *argv[]) {
         int line_count = count_lines(wal_file);
         // The cursor must be reset after counting the lines, as this takes
         // us to EOF.
-        fseek(wal_file, SEEK_SET, 0);
+        // We do not reset to the beginning of the file, rather after the header,
+        // which is known to exist at this point.
+        int res = fseek(wal_file, strlen(WAL_HEADER), SEEK_SET);
+        if (res != 0) {
+            fprintf(stderr, "Unable to seek cursor to after the WAL header.\n");
+            exit(EXIT_FAILURE);
+        }
 
         int i;
         for (i=0; i < line_count; i++) {

--- a/wal.c
+++ b/wal.c
@@ -4,13 +4,13 @@
 #include <string.h>
 
 bool has_header(FILE *wal_file) {
-    fseek(wal_file, SEEK_SET, 0);
-    char header[2];
-    fread(header, sizeof(char), 2, wal_file);
-
+    char header[strlen(WAL_HEADER) + 1]; // header + NULL terminator
+    fseek(wal_file, 0, SEEK_SET);
+    fread(header, sizeof(char), strlen(WAL_HEADER), wal_file);
+    header[2] = '\0';
     return strcmp(header, WAL_HEADER) == 0;
 }
 
 void write_header(FILE *wal_file) {
-    fwrite(WAL_HEADER, sizeof(char), 2, wal_file);
+    fwrite(WAL_HEADER, sizeof(WAL_HEADER[0]), strlen(WAL_HEADER), wal_file);
 }

--- a/wal.c
+++ b/wal.c
@@ -1,8 +1,16 @@
 #include "wal.h"
 #include "stdio.h"
+#include <stdio.h>
+#include <string.h>
 
-char* generate_wal_path(char *dir, int id) {
-    char* path;
-    asprintf(&path, "%s/%d.wal", dir, id);
-    return path;
+bool has_header(FILE *wal_file) {
+    fseek(wal_file, SEEK_SET, 0);
+    char header[2];
+    fread(header, sizeof(char), 2, wal_file);
+
+    return strcmp(header, WAL_HEADER) == 0;
+}
+
+void write_header(FILE *wal_file) {
+    fwrite(WAL_HEADER, sizeof(char), 2, wal_file);
 }

--- a/wal.h
+++ b/wal.h
@@ -1,16 +1,21 @@
 #ifndef WAL_H_
 #define WAL_H_
 
+#include <stdio.h>
+#include <stdbool.h>
+
+#define WAL_HEADER "w0"
+
 typedef struct S {
     char* key;
     char* value;
 } SegmentEntry;
 
-typedef struct W {} Wal;
 
-// Creates a WAL path with an input directory and ID.
-char* generate_wal_path(char* dir, int id);
+// Check whether a WAL file has the expected header.
+bool has_header(FILE* wal_file);
 
-Wal new_wal(char* path);
+// Write the WAL_HEADER to a WAL file.
+void write_header(FILE* wal_file);
 
 #endif

--- a/wal.h
+++ b/wal.h
@@ -4,7 +4,8 @@
 #include <stdio.h>
 #include <stdbool.h>
 
-#define WAL_HEADER "w0"
+// Magic bytes that are expected at the start of a WAL file.
+#define WAL_HEADER "w1"
 
 typedef struct S {
     char* key;


### PR DESCRIPTION
Closes https://github.com/jdockerty/wal-c/issues/2

By encoding a 2 byte header, `w1` at the moment`, this allows the tool to know whether the file it is reading is an expected WAL file that has been produced by the tool.

Technically this doesn't matter, since it could simply read a file line by line and print it out, but this is a good learning exercise for C 😄 
