### PR TITLE
feat: add `close` subcmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@ key-value pairs as either an insertion or deletion operation.
 
 ## Usage
 
-A CLI tool is provided to act as an entrypoint to the WAL operations.
+A CLI tool is provided to act as an entrypoint to the WAL operations[^1].
 
-- `wal-c create <path/to/dir>`: Create a WAL file within the given directory
-- `wal-c write <path/to/dir> k=v,k=v,...`: Write an arbitrary number of key-value pairs to the WAL directory
-- `wal-c replay <path>`: Replay the values written into the WAL directory
+[^1]: A WAL works much better for longer running operations than for a CLI, so
+this is really a glorified file read/writer.
+
+- `wal-c write PATH_TO_FILE k=v,k=v,...`: Write an arbitrary number of key-value pairs to the file 
+- `wal-c replay PATH_TO_FILE`: Replay the values written into the WAL directory
+- `wal-c close PATH_TO_FILE`: Closes a file, encoding metadata and marking it as immutable. 

--- a/main.c
+++ b/main.c
@@ -122,10 +122,13 @@ int main(int argc, char *argv[]) {
             exit(EXIT_FAILURE);
         }
 
-        int line_count = count_lines(wal_file);
-        // The cursor must be reset after counting the lines, as this takes
-        // us to EOF.
-        // We do not reset to the beginning of the file, rather after the header,
+        int entries_res = fseek(wal_file, -sizeof(int), SEEK_END);
+        int num_entries;
+        fread(&num_entries, sizeof(int), 1, wal_file);
+
+        // The cursor must be reset after reading the metadata, as this takes us 
+        // to near-EOF.
+        // We do not reset to the beginning of the file, rather after the header
         // which is known to exist at this point.
         int res = fseek(wal_file, strlen(WAL_HEADER), SEEK_SET);
         if (res != 0) {
@@ -154,8 +157,34 @@ int main(int argc, char *argv[]) {
             // simply be discarded.
             fgetc(wal_file);
         }
-
         fclose(wal_file);
+    } else if (strcmp(subcmd, "close") == 0) {
+        char* wal_path = argv[2];
+        if (wal_path == NULL) {
+            fprintf(stderr, "Must provide a directory.\n");
+            exit(EXIT_FAILURE);
+        }
+
+        FILE * wal_file;
+        wal_file = fopen(wal_path, "a+");
+        if (wal_file == NULL) {
+            exit(EXIT_FAILURE);
+        }
+
+        fseek(wal_file, 0, SEEK_SET);
+
+        if (!has_header(wal_file)) {
+            fprintf(stderr, "%s is not a WAL file, the expected header was not present.\n", wal_path);
+            exit(EXIT_FAILURE);
+        }
+
+        int entries = count_lines(wal_file);
+        // Seek to the end of the file so that we can encode the metadata.
+        fseek(wal_file, 0, SEEK_END);
+
+        int bytes = fwrite(&entries, sizeof(int), 1, wal_file);
+        fclose(wal_file);
+        fprintf(stderr, "%s has been closed and marked as immutable.\n", wal_path);
     } else {
         printf("Unrecognised command: %s\n", subcmd);
         exit(EXIT_FAILURE);

--- a/main.c
+++ b/main.c
@@ -137,7 +137,7 @@ int main(int argc, char *argv[]) {
         }
 
         int i;
-        for (i=0; i < line_count; i++) {
+        for (i=0; i < num_entries; i++) {
             int key_len, value_len;
 
             // Read the key/value lengths that were encoded.

--- a/wal.h
+++ b/wal.h
@@ -19,4 +19,11 @@ bool has_header(FILE* wal_file);
 // Write the WAL_HEADER to a WAL file.
 void write_header(FILE* wal_file);
 
+// Check whether a WAL file has been closed and declared as immutable.
+bool is_closed(FILE* wal_file);
+
+// Retrieve the number of entries written to the file. This comes from the
+// encoded metadata at the footer of the file.
+int entries_metadata(FILE* wal_file);
+
 #endif


### PR DESCRIPTION
Closes https://github.com/jdockerty/wal-c/issues/3 and https://github.com/jdockerty/wal-c/issues/4

This adds a `close` subcommand, which will encode some metadata to the footer of the file, this is simply the number of entries that were written.